### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Building Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: '${{ secrets.DOCKER_IMAGE }}'
           username: '${{ secrets.DOCKER_USERNAME }}'


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore